### PR TITLE
src/commands: support migrate rebase

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -188,6 +188,27 @@ jobs:
             grep -qe "INPUT_WAIT_TIMEOUT=2m" /tmp/env.out
             # check vars should be set in the environment
             grep -qe "INPUT_VARS={\"foo\": \"bar\", \"baz\": \"qux\", \"quux\": \"corge\"}" /tmp/env.out
+  command-test-migrate-rebase:
+    executor: atlas-orb/default
+    steps:
+      - checkout
+      - run:
+          name: Mock atlas with echo.sh
+          command: |
+            sudo cp ./src/scripts/echo.sh /bin/atlas
+            sudo cp ./src/scripts/echo.sh /bin/atlasaction
+      - atlas-orb/migrate_auto_rebase:
+          working_directory: testdata
+          base_branch: "master"
+          dir: "file://migrations"
+      - run:
+          name: Check echo.out for expected output
+          command: |
+            grep -qe "--action migrate/autorebase" /tmp/echo.out
+            # check dir should be set in the environment
+            grep -qe "INPUT_DIR=file://migrations" /tmp/env.out
+            # check base_branch should be set in the environment
+            grep -qe "INPUT_BASE_BRANCH=master" /tmp/env.out
   command-test-migrate-test:
     executor: atlas-orb/default
     steps:
@@ -505,6 +526,10 @@ jobs:
           run: "expected_success"
           dir: atlas://my-cool-project
           dev_url: postgres://postgres:pass@localhost:5432/test?search_path=public&sslmode=disable
+      - atlas-orb/migrate_auto_rebase:
+          working_directory: testdata
+          base_branch: "master"
+          dir: "file://migrations"
       - atlas-orb/migrate_lint:
           working_directory: testdata
           dir_name: my-cool-project
@@ -681,6 +706,8 @@ workflows:
           filters: *filters
       - command-test-migrate-down:
           filters: *filters
+      - command-test-migrate-rebase:
+          filters: *filters
       - command-test-schema-test:
           filters: *filters
       - command-test-schema-push:
@@ -701,6 +728,7 @@ workflows:
             - command-test-migrate-lint
             - command-test-migrate-apply
             - command-test-migrate-down
+            - command-test-migrate-rebase
       - integration-test-versioned-gh:
           context: ariga-atlas-gh
           filters: *filters
@@ -711,6 +739,7 @@ workflows:
             - command-test-migrate-lint
             - command-test-migrate-apply
             - command-test-migrate-down
+            - command-test-migrate-rebase
       - integration-test-versioned-gh-lint:
           context: ariga-atlas-gh
           filters: *filters
@@ -762,6 +791,7 @@ workflows:
             - command-test-migrate-lint
             - command-test-migrate-apply
             - command-test-migrate-down
+            - command-test-migrate-rebase
             - command-test-schema-test
           context: orb-publisher
           filters: *release-filters

--- a/src/commands/migrate_auto_rebase.yml
+++ b/src/commands/migrate_auto_rebase.yml
@@ -1,0 +1,27 @@
+description: >
+  This command rebases migrations to a database.
+
+parameters:
+  base_branch:
+    description: |
+      The base branch to rebase the migration directory onto. Default to the default branch of the repository.
+    type: string
+    default: 'main'
+  dir:
+    type: string
+    default: "file://migrations"
+    description: |
+      The URL of the migration directory to rebase on. By default: `file://migrations`.
+  working_directory:
+    type: string
+    default: "."
+    description: |
+      The working directory to run from. Defaults to project root.
+steps:
+  - run:
+      name: Rebase migrations to a database
+      command: atlasaction --action migrate/autorebase
+      environment:
+        ATLAS_INPUT_WORKING_DIRECTORY: <<parameters.working_directory>>
+        ATLAS_INPUT_DIR: <<parameters.dir>>
+        ATLAS_INPUT_BASE_BRANCH: <<parameters.base_branch>>


### PR DESCRIPTION
This pull request introduces a new command for rebasing migrations and integrates it into the CircleCI configuration. The most important changes include the addition of the new command, updates to the CircleCI job definitions, and modifications to the CircleCI workflows to include the new command.

### New Command Addition:
* [`src/commands/migrate_auto_rebase.yml`](diffhunk://#diff-c8821d3f57f7cc291de693cb91b6c8cdc5354a50996dc034e1f1cee50659f847R1-R27): Added a new command definition for rebasing migrations with parameters for `rebase_branch`, `dir`, and `working_directory`.

### CircleCI Job Updates:
* [`.circleci/test-deploy.yml`](diffhunk://#diff-1d3c0150af90ce1dd4e8ff2ce93160721d21a31790a051a5ab2b6aac49704535R191-R211): Added a new job `command-test-migrate-rebase` to execute the rebase command.

### CircleCI Workflow Updates:
* [`.circleci/test-deploy.yml`](diffhunk://#diff-1d3c0150af90ce1dd4e8ff2ce93160721d21a31790a051a5ab2b6aac49704535R705-R706): Updated the `workflows` section to include the new `command-test-migrate-rebase` job in various workflows. [[1]](diffhunk://#diff-1d3c0150af90ce1dd4e8ff2ce93160721d21a31790a051a5ab2b6aac49704535R705-R706) [[2]](diffhunk://#diff-1d3c0150af90ce1dd4e8ff2ce93160721d21a31790a051a5ab2b6aac49704535R727) [[3]](diffhunk://#diff-1d3c0150af90ce1dd4e8ff2ce93160721d21a31790a051a5ab2b6aac49704535R738) [[4]](diffhunk://#diff-1d3c0150af90ce1dd4e8ff2ce93160721d21a31790a051a5ab2b6aac49704535R790)